### PR TITLE
Fixes bug that didn't update the serial number for an existing ZONEMD…

### DIFF
--- a/tools/digest.go
+++ b/tools/digest.go
@@ -215,6 +215,7 @@ func (ctx *Context) UpdateDigest() (err error) {
 		return
 	}
 	ctx.zonemd[digestedPosition].Digest = digest
+	ctx.zonemd[digestedPosition].Serial = ctx.soa.Serial
 	return nil
 }
 


### PR DESCRIPTION
Doing a digest command with a zone which had an old ZONEMD record, the digest itself is rightly recalculated, but the serial field wasn't updated. The new ZONEMD record must have the same serial field as the SOA serial of the new zone.
